### PR TITLE
test: Create test for updating inverse relation variables on entities that supports pinning

### DIFF
--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/bavet/BavetSolutionManagerTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/bavet/BavetSolutionManagerTest.java
@@ -4,6 +4,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintStreamImplType;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.impl.solver.AbstractSolutionManagerTest;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataConstraintProvider;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned_values.TestdataAllowsUnassignedValuesListConstraintProvider;
 
 final class BavetSolutionManagerTest extends AbstractSolutionManagerTest {
 
@@ -11,6 +12,13 @@ final class BavetSolutionManagerTest extends AbstractSolutionManagerTest {
     protected ScoreDirectorFactoryConfig buildScoreDirectorFactoryConfig() {
         return new ScoreDirectorFactoryConfig()
                 .withConstraintProviderClass(TestdataConstraintProvider.class)
+                .withConstraintStreamImplType(ConstraintStreamImplType.BAVET);
+    }
+
+    @Override
+    protected ScoreDirectorFactoryConfig buildUnassignedScoreDirectorFactoryConfig() {
+        return new ScoreDirectorFactoryConfig()
+                .withConstraintProviderClass(TestdataAllowsUnassignedValuesListConstraintProvider.class)
                 .withConstraintStreamImplType(ConstraintStreamImplType.BAVET);
     }
 

--- a/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/uni/AbstractUniConstraintStreamTest.java
+++ b/core/constraint-streams/src/test/java/ai/timefold/solver/constraint/streams/common/uni/AbstractUniConstraintStreamTest.java
@@ -1238,6 +1238,8 @@ public abstract class AbstractUniConstraintStreamTest
         solution.setValueList(List.of(v1, v2));
         var e1 = new TestdataAllowsUnassignedValuesListEntity("e1", v1);
         var e2 = new TestdataAllowsUnassignedValuesListEntity("e2");
+        v1.setEntity(e1);
+        v1.setIndex(0);
         solution.setEntityList(List.of(e1, e2));
 
         InnerScoreDirector<TestdataAllowsUnassignedValuesListSolution, SimpleScore> scoreDirector = buildScoreDirector(

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/solver/AbstractSolutionManagerTest.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/solver/AbstractSolutionManagerTest.java
@@ -1,5 +1,7 @@
 package ai.timefold.solver.core.impl.solver;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -8,11 +10,15 @@ import ai.timefold.solver.core.api.score.buildin.simple.SimpleScore;
 import ai.timefold.solver.core.api.score.stream.DefaultConstraintJustification;
 import ai.timefold.solver.core.api.solver.SolutionManager;
 import ai.timefold.solver.core.api.solver.SolutionManagerTest;
+import ai.timefold.solver.core.api.solver.SolutionUpdatePolicy;
 import ai.timefold.solver.core.api.solver.SolverFactory;
 import ai.timefold.solver.core.config.score.director.ScoreDirectorFactoryConfig;
 import ai.timefold.solver.core.config.solver.SolverConfig;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataEntity;
 import ai.timefold.solver.core.impl.testdata.domain.TestdataSolution;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned_values.TestdataAllowsUnassignedValuesListEntity;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned_values.TestdataAllowsUnassignedValuesListSolution;
+import ai.timefold.solver.core.impl.testdata.domain.list.allows_unassigned_values.TestdataAllowsUnassignedValuesListValue;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -20,6 +26,8 @@ import org.junit.jupiter.api.Test;
 public abstract class AbstractSolutionManagerTest {
 
     protected abstract ScoreDirectorFactoryConfig buildScoreDirectorFactoryConfig();
+
+    protected abstract ScoreDirectorFactoryConfig buildUnassignedScoreDirectorFactoryConfig();
 
     @Test
     void indictmentsPresentOnFreshExplanation() {
@@ -52,6 +60,34 @@ public abstract class AbstractSolutionManagerTest {
             softly.assertThat(scoreExplanation.getJustificationList(DefaultConstraintJustification.class))
                     .containsExactlyElementsOf(constraintJustificationList);
         });
+    }
+
+    @Test
+    void updateAssignedValueWithNullInverseRelation() {
+        // Create the environment.
+        ScoreDirectorFactoryConfig scoreDirectorFactoryConfig = buildUnassignedScoreDirectorFactoryConfig();
+        SolverConfig solverConfig = new SolverConfig();
+        solverConfig.setSolutionClass(TestdataAllowsUnassignedValuesListSolution.class);
+        solverConfig.setEntityClassList(
+                List.of(TestdataAllowsUnassignedValuesListEntity.class, TestdataAllowsUnassignedValuesListValue.class));
+        solverConfig.setScoreDirectorFactoryConfig(scoreDirectorFactoryConfig);
+        SolverFactory<TestdataAllowsUnassignedValuesListSolution> solverFactory = SolverFactory.create(solverConfig);
+        SolutionManager<TestdataAllowsUnassignedValuesListSolution, SimpleScore> solutionManager =
+                SolutionManagerTest.SolutionManagerSource.FROM_SOLVER_FACTORY.createSolutionManager(solverFactory);
+
+        // Prepare the solution.
+        var solution = new TestdataAllowsUnassignedValuesListSolution();
+        var entity = new TestdataAllowsUnassignedValuesListEntity("e1");
+        var assignedValue = new TestdataAllowsUnassignedValuesListValue("assigned");
+
+        entity.setValueList(List.of(assignedValue));
+
+        solution.setEntityList(List.of(entity));
+        solution.setValueList(List.of(assignedValue));
+        solutionManager.update(solution, SolutionUpdatePolicy.UPDATE_SHADOW_VARIABLES_ONLY);
+
+        assertThat(assignedValue.getEntity()).isSameAs(entity);
+        assertThat(assignedValue.getIndex()).isZero();
     }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/allows_unassigned_values/TestdataAllowsUnassignedValuesListConstraintProvider.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/allows_unassigned_values/TestdataAllowsUnassignedValuesListConstraintProvider.java
@@ -9,14 +9,22 @@ public final class TestdataAllowsUnassignedValuesListConstraintProvider implemen
     @Override
     public Constraint[] defineConstraints(ConstraintFactory constraintFactory) {
         return new Constraint[] {
-                onlyConstraint(constraintFactory)
+                entityConstraint(constraintFactory),
+                valueConstraint(constraintFactory)
         };
     }
 
-    private Constraint onlyConstraint(ConstraintFactory constraintFactory) {
+    private Constraint entityConstraint(ConstraintFactory constraintFactory) {
         return constraintFactory.forEach(TestdataAllowsUnassignedValuesListEntity.class)
                 .penalize(SimpleScore.ONE, e -> e.getValueList().size())
-                .asConstraint("First weight");
+                .asConstraint("Entity list size");
+    }
+
+    private Constraint valueConstraint(ConstraintFactory constraintFactory) {
+        return constraintFactory.forEachIncludingUnassigned(TestdataAllowsUnassignedValuesListValue.class)
+                .filter(value -> value.getEntity() == null)
+                .penalize(SimpleScore.ONE)
+                .asConstraint("Unassigned values");
     }
 
 }

--- a/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/allows_unassigned_values/TestdataAllowsUnassignedValuesListEntity.java
+++ b/core/core-impl/src/test/java/ai/timefold/solver/core/impl/testdata/domain/list/allows_unassigned_values/TestdataAllowsUnassignedValuesListEntity.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import ai.timefold.solver.core.api.domain.entity.PlanningEntity;
+import ai.timefold.solver.core.api.domain.entity.PlanningPinToIndex;
 import ai.timefold.solver.core.api.domain.variable.PlanningListVariable;
 import ai.timefold.solver.core.impl.domain.entity.descriptor.EntityDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
@@ -65,6 +66,14 @@ public class TestdataAllowsUnassignedValuesListEntity extends TestdataObject {
 
     public void setValueList(List<TestdataAllowsUnassignedValuesListValue> valueList) {
         this.valueList = valueList;
+    }
+
+    @PlanningPinToIndex
+    public int getPlanningPinnedToIndex() {
+        // Always return 0, since we don't want to actually pin anything,
+        // but need to "support" pinning to test branches that only occur if
+        // pinning is present
+        return 0;
     }
 
 }


### PR DESCRIPTION
Currently, doing an update on a value with a null inverse relation variable but is assigned to an entity causes an IllegalStateException to be thrown in a forEach node, even if only shadow variables are updated. It requires the model to supports pinning, since it is caused by a branch that is only triggered if the model supports pinning.