### PR TITLE
fix: notify the neighborhood move repository when internal state changes

### DIFF
--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ExternalizedListVariableStateSupply.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ExternalizedListVariableStateSupply.java
@@ -1,6 +1,7 @@
 package ai.timefold.solver.core.impl.domain.variable;
 
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.index.IndexShadowVariableDescriptor;
@@ -27,9 +28,11 @@ final class ExternalizedListVariableStateSupply<Solution_, Entity_>
     @Nullable
     private Solution_ workingSolution;
 
-    public ExternalizedListVariableStateSupply(ListVariableDescriptor<Solution_> sourceVariableDescriptor) {
+    public ExternalizedListVariableStateSupply(ListVariableDescriptor<Solution_> sourceVariableDescriptor,
+            Consumer<Object> notifier) {
         this.sourceVariableDescriptor = sourceVariableDescriptor;
-        this.listVariableState = new ListVariableState<>(sourceVariableDescriptor);
+        this.listVariableState = new ListVariableState<>(sourceVariableDescriptor,
+                notifier);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ListVariableState.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ListVariableState.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescriptor;
 import ai.timefold.solver.core.impl.domain.variable.index.IndexShadowVariableDescriptor;
@@ -16,6 +17,7 @@ import ai.timefold.solver.core.preview.api.domain.metamodel.PositionInList;
 final class ListVariableState<Solution_> {
 
     private final ListVariableDescriptor<Solution_> sourceVariableDescriptor;
+    private final Consumer<Object> notifier;
 
     private ExternalizedIndexVariableProcessor<Solution_> externalizedIndexProcessor = null;
     private ExternalizedListInverseVariableProcessor<Solution_> externalizedInverseProcessor = null;
@@ -27,8 +29,10 @@ final class ListVariableState<Solution_> {
     private int unassignedCount = 0;
     private Map<Object, MutablePosition> elementPositionMap;
 
-    public ListVariableState(ListVariableDescriptor<Solution_> sourceVariableDescriptor) {
+    public ListVariableState(ListVariableDescriptor<Solution_> sourceVariableDescriptor,
+            Consumer<Object> notifier) {
         this.sourceVariableDescriptor = sourceVariableDescriptor;
+        this.notifier = notifier;
     }
 
     public void linkShadowVariable(IndexShadowVariableDescriptor<Solution_> shadowVariableDescriptor) {
@@ -133,6 +137,7 @@ final class ListVariableState<Solution_> {
         if (externalizedNextElementProcessor != null) {
             externalizedNextElementProcessor.setElement(scoreDirector, elements, element, index);
         }
+        notifier.accept(element);
         unassignedCount--;
     }
 
@@ -157,6 +162,7 @@ final class ListVariableState<Solution_> {
         if (externalizedNextElementProcessor != null) {
             externalizedNextElementProcessor.unsetElement(scoreDirector, element);
         }
+        notifier.accept(element);
         unassignedCount++;
     }
 
@@ -177,6 +183,7 @@ final class ListVariableState<Solution_> {
         if (externalizedNextElementProcessor != null) {
             externalizedNextElementProcessor.setElement(scoreDirector, elements, element, index);
         }
+        notifier.accept(element);
         return difference.anythingChanged;
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ListVariableStateDemand.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/ListVariableStateDemand.java
@@ -14,7 +14,7 @@ public final class ListVariableStateDemand<Solution_>
     @Override
     public ListVariableStateSupply<Solution_, Object, Object> createExternalizedSupply(SupplyManager supplyManager) {
         var listVariableDescriptor = (ListVariableDescriptor<Solution_>) variableDescriptor;
-        return new ExternalizedListVariableStateSupply<>(listVariableDescriptor);
+        return new ExternalizedListVariableStateSupply<>(listVariableDescriptor, supplyManager.getStateChangeNotifier());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/anchor/AnchorVariableDemand.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/anchor/AnchorVariableDemand.java
@@ -21,7 +21,8 @@ public final class AnchorVariableDemand<Solution_>
     public AnchorVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
         SingletonInverseVariableSupply inverseVariableSupply = supplyManager
                 .demand(new SingletonInverseVariableDemand<>(variableDescriptor));
-        return new ExternalizedAnchorVariableSupply<>(variableDescriptor, inverseVariableSupply);
+        return new ExternalizedAnchorVariableSupply<>(variableDescriptor, inverseVariableSupply,
+                supplyManager.getStateChangeNotifier());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/anchor/ExternalizedAnchorVariableSupply.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/anchor/ExternalizedAnchorVariableSupply.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.anchor;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import ai.timefold.solver.core.impl.domain.variable.BasicVariableChangeEvent;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
@@ -23,12 +24,15 @@ public class ExternalizedAnchorVariableSupply<Solution_> implements
     protected final VariableDescriptor<Solution_> previousVariableDescriptor;
     protected final SingletonInverseVariableSupply nextVariableSupply;
     protected final Map<Object, @Nullable Object> anchorMap;
+    private final Consumer<Object> notifier;
 
     public ExternalizedAnchorVariableSupply(VariableDescriptor<Solution_> previousVariableDescriptor,
-            SingletonInverseVariableSupply nextVariableSupply) {
+            SingletonInverseVariableSupply nextVariableSupply,
+            Consumer<Object> notifier) {
         this.previousVariableDescriptor = previousVariableDescriptor;
         this.nextVariableSupply = nextVariableSupply;
         this.anchorMap = new IdentityHashMap<>();
+        this.notifier = notifier;
     }
 
     @Override
@@ -72,6 +76,7 @@ public class ExternalizedAnchorVariableSupply<Solution_> implements
         Object nextEntity = entity;
         while (nextEntity != null && anchorMap.get(nextEntity) != anchor) {
             anchorMap.put(nextEntity, anchor);
+            notifier.accept(nextEntity);
             nextEntity = nextVariableSupply.getInverseSingleton(nextEntity);
         }
     }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/CollectionInverseVariableDemand.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/CollectionInverseVariableDemand.java
@@ -21,7 +21,7 @@ public final class CollectionInverseVariableDemand<Solution_>
 
     @Override
     public CollectionInverseVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
-        return new ExternalizedCollectionInverseVariableSupply<>(variableDescriptor);
+        return new ExternalizedCollectionInverseVariableSupply<>(variableDescriptor, supplyManager.getStateChangeNotifier());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/ExternalizedCollectionInverseVariableSupply.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/ExternalizedCollectionInverseVariableSupply.java
@@ -5,6 +5,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import ai.timefold.solver.core.impl.domain.variable.BasicVariableChangeEvent;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
@@ -21,11 +22,14 @@ public class ExternalizedCollectionInverseVariableSupply<Solution_> implements
         CollectionInverseVariableSupply {
 
     protected final VariableDescriptor<Solution_> sourceVariableDescriptor;
+    protected final Consumer<Object> notifier;
 
     protected Map<Object, Set<Object>> inverseEntitySetMap = null;
 
-    public ExternalizedCollectionInverseVariableSupply(VariableDescriptor<Solution_> sourceVariableDescriptor) {
+    public ExternalizedCollectionInverseVariableSupply(VariableDescriptor<Solution_> sourceVariableDescriptor,
+            Consumer<Object> notifier) {
         this.sourceVariableDescriptor = sourceVariableDescriptor;
+        this.notifier = notifier;
     }
 
     @Override
@@ -70,6 +74,7 @@ public class ExternalizedCollectionInverseVariableSupply<Solution_> implements
                     + ") for sourceVariable (" + sourceVariableDescriptor.getVariableName()
                     + ") cannot be inserted: it was already inserted.");
         }
+        notifier.accept(value);
     }
 
     protected void retract(Object entity) {
@@ -88,6 +93,7 @@ public class ExternalizedCollectionInverseVariableSupply<Solution_> implements
         if (inverseEntitySet.isEmpty()) {
             inverseEntitySetMap.put(value, null);
         }
+        notifier.accept(value);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupply.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupply.java
@@ -2,6 +2,7 @@ package ai.timefold.solver.core.impl.domain.variable.inverserelation;
 
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import ai.timefold.solver.core.impl.domain.variable.BasicVariableChangeEvent;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.VariableDescriptor;
@@ -18,11 +19,14 @@ public class ExternalizedSingletonInverseVariableSupply<Solution_> implements
         SingletonInverseVariableSupply {
 
     protected final VariableDescriptor<Solution_> sourceVariableDescriptor;
+    private final Consumer<Object> notifier;
 
     protected Map<Object, Object> inverseEntityMap = null;
 
-    public ExternalizedSingletonInverseVariableSupply(VariableDescriptor<Solution_> sourceVariableDescriptor) {
+    public ExternalizedSingletonInverseVariableSupply(VariableDescriptor<Solution_> sourceVariableDescriptor,
+            Consumer<Object> notifier) {
         this.sourceVariableDescriptor = sourceVariableDescriptor;
+        this.notifier = notifier;
     }
 
     @Override
@@ -66,6 +70,7 @@ public class ExternalizedSingletonInverseVariableSupply<Solution_> implements
                     + ") cannot be inserted: another entity (" + oldInverseEntity
                     + ") already has that value (" + value + ").");
         }
+        notifier.accept(value);
     }
 
     protected void retract(Object entity) {
@@ -80,6 +85,7 @@ public class ExternalizedSingletonInverseVariableSupply<Solution_> implements
                     + ") for sourceVariable (" + sourceVariableDescriptor.getVariableName()
                     + ") cannot be retracted: the entity was never inserted for that value (" + value + ").");
         }
+        notifier.accept(value);
     }
 
     @Override

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/SingletonInverseVariableDemand.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/SingletonInverseVariableDemand.java
@@ -17,7 +17,7 @@ public final class SingletonInverseVariableDemand<Solution_>
 
     @Override
     public SingletonInverseVariableSupply createExternalizedSupply(SupplyManager supplyManager) {
-        return new ExternalizedSingletonInverseVariableSupply<>(variableDescriptor);
+        return new ExternalizedSingletonInverseVariableSupply<>(variableDescriptor, supplyManager.getStateChangeNotifier());
     }
 
 }

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupport.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
 
 import ai.timefold.solver.core.api.domain.solution.PlanningSolution;
@@ -166,6 +167,11 @@ public final class VariableListenerSupport<Solution_> implements SupplyManager {
                     AbstractNotifiable.buildNotifiable(scoreDirector, variableListener, globalOrder));
             nextGlobalOrder = globalOrder + 1;
         }
+    }
+
+    @Override
+    public Consumer<Object> getStateChangeNotifier() {
+        return scoreDirector.getNeighborhoodNotifier();
     }
 
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/supply/SupplyManager.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/domain/variable/supply/SupplyManager.java
@@ -1,9 +1,24 @@
 package ai.timefold.solver.core.impl.domain.variable.supply;
 
+import java.util.function.Consumer;
+
+import ai.timefold.solver.core.impl.domain.variable.inverserelation.ExternalizedSingletonInverseVariableSupply;
+import ai.timefold.solver.core.impl.neighborhood.NeighborhoodsBasedMoveRepository;
+
 /**
  * Provides a {@link Supply} for subsystems that submit a {@link Demand}.
  */
 public interface SupplyManager {
+    /**
+     * Returns a {@link Consumer} that notifies internal components (such as {@link NeighborhoodsBasedMoveRepository})
+     * when the {@link Supply} changes.
+     * <p>
+     * This is required to be used for externalized supplies (such as {@link ExternalizedSingletonInverseVariableSupply}), since
+     * their state can change without modifying any variables on an entity.
+     * 
+     * @return never null
+     */
+    Consumer<Object> getStateChangeNotifier();
 
     /**
      * Returns the {@link Supply} for a {@link Demand}, preferably an existing one.

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/AbstractScoreDirector.java
@@ -73,7 +73,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
     protected final Factory_ scoreDirectorFactory;
     private final VariableDescriptorCache<Solution_> variableDescriptorCache;
     protected final VariableListenerSupport<Solution_> variableListenerSupport;
-
+    protected final NeighborhoodNotifier neighborhoodNotifier;
     private boolean expectShadowVariablesInCorrectState;
 
     private long workingEntityListRevision = 0L;
@@ -104,6 +104,7 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         this.lookUpManager = lookUpEnabled ? new LookUpManager(solutionDescriptor.getLookUpStrategyResolver()) : null;
         this.constraintMatchPolicy = builder.constraintMatchPolicy;
         this.expectShadowVariablesInCorrectState = builder.expectShadowVariablesInCorrectState;
+        this.neighborhoodNotifier = new NeighborhoodNotifier<>();
         this.variableDescriptorCache = new VariableDescriptorCache<>(solutionDescriptor);
         this.variableListenerSupport = VariableListenerSupport.create(this);
         this.variableListenerSupport.linkVariableListeners();
@@ -217,6 +218,10 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         return moveDirector;
     }
 
+    public NeighborhoodNotifier<Solution_> getNeighborhoodNotifier() {
+        return neighborhoodNotifier;
+    }
+
     // ************************************************************************
     // Complex methods
     // ************************************************************************
@@ -301,6 +306,11 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         if (moveRepository != null) {
             moveRepository.initialize(new SessionContext<>(this));
         }
+        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository) {
+            neighborhoodNotifier.setMoveRepository(neighborhoodsBasedMoveRepository);
+        } else {
+            neighborhoodNotifier.setMoveRepository(null);
+        }
     }
 
     private void assertInitScoreZeroOrLess() {
@@ -314,7 +324,9 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
 
     @Override
     public void executeMove(Move<Solution_> move) {
+        neighborhoodNotifier.setTracking(true);
         moveDirector.execute(move);
+        neighborhoodNotifier.setTracking(false);
     }
 
     @Override
@@ -486,7 +498,8 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
         if (variableDescriptor.isGenuineAndUninitialized(entity)) {
             workingInitScore--;
         }
-        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository) {
+        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository
+                && !allChangesWillBeUndoneBeforeStepEnds) {
             neighborhoodsBasedMoveRepository.update(entity);
         }
         variableListenerSupport.afterVariableChanged(variableDescriptor, entity);
@@ -502,7 +515,8 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             workingInitScore++;
             assertInitScoreZeroOrLess();
         }
-        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository) {
+        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository
+                && !allChangesWillBeUndoneBeforeStepEnds) {
             neighborhoodsBasedMoveRepository.update(element);
         }
     }
@@ -518,7 +532,8 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
             workingInitScore--;
         }
         variableListenerSupport.afterElementUnassigned(variableDescriptor, element);
-        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository) {
+        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository
+                && !allChangesWillBeUndoneBeforeStepEnds) {
             neighborhoodsBasedMoveRepository.update(element);
         }
     }
@@ -537,47 +552,15 @@ public abstract class AbstractScoreDirector<Solution_, Score_ extends Score<Scor
                             .formatted(variableDescriptor, entity, fromIndex, toIndex));
         }
         variableListenerSupport.beforeListVariableChanged(variableDescriptor, entity, fromIndex, toIndex);
-        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository) {
-            ensureBoundaryUpdates(neighborhoodsBasedMoveRepository, variableDescriptor, entity, fromIndex, toIndex);
-        }
-    }
-
-    private static <Solution_> void ensureBoundaryUpdates(
-            NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository,
-            ListVariableDescriptor<Solution_> variableDescriptor, Object entity, int fromIndex, int toIndex) {
-        // In cases where fromIndex and toIndex on list var update is the same (= empty list)
-        // it means that an element is either getting added or removed.
-        // These changes are typically reflected by the variable listener machinery,
-        // but in this case we need to manually ensure the neighbors are updated.
-        // This is because the empty list would only come in the before method,
-        // but all processing happens in the after method.
-        // Between the before- and after- methods, the list would have been updated already,
-        // and therefore the information about the original boundary element is lost.
-        if (fromIndex != toIndex) {
-            return;
-        }
-        var list = variableDescriptor.getValue(entity);
-        if (list.isEmpty()) {
-            return;
-        }
-        var bound = list.size() - 1;
-        if (fromIndex >= 0 && fromIndex <= bound) {
-            if (fromIndex > 0) {
-                neighborhoodsBasedMoveRepository.update(list.get(fromIndex - 1));
-            }
-            if (fromIndex < bound) {
-                neighborhoodsBasedMoveRepository.update(list.get(fromIndex + 1));
-            }
-        }
     }
 
     @Override
     public void afterListVariableChanged(ListVariableDescriptor<Solution_> variableDescriptor, Object entity, int fromIndex,
             int toIndex) {
         variableListenerSupport.afterListVariableChanged(variableDescriptor, entity, fromIndex, toIndex);
-        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository) {
+        if (moveRepository instanceof NeighborhoodsBasedMoveRepository<Solution_> neighborhoodsBasedMoveRepository
+                && !allChangesWillBeUndoneBeforeStepEnds) {
             neighborhoodsBasedMoveRepository.update(entity);
-            ensureBoundaryUpdates(neighborhoodsBasedMoveRepository, variableDescriptor, entity, fromIndex, toIndex);
         }
     }
 

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/InnerScoreDirector.java
@@ -32,6 +32,7 @@ import ai.timefold.solver.core.impl.domain.variable.descriptor.ListVariableDescr
 import ai.timefold.solver.core.impl.domain.variable.supply.SupplyManager;
 import ai.timefold.solver.core.impl.move.MoveDirector;
 import ai.timefold.solver.core.impl.neighborhood.MoveRepository;
+import ai.timefold.solver.core.impl.neighborhood.NeighborhoodsBasedMoveRepository;
 import ai.timefold.solver.core.impl.phase.scope.SolverLifecyclePoint;
 import ai.timefold.solver.core.impl.score.constraint.ConstraintMatchPolicy;
 import ai.timefold.solver.core.impl.score.definition.ScoreDefinition;
@@ -111,6 +112,14 @@ public interface InnerScoreDirector<Solution_, Score_ extends Score<Score_>>
      * and also calling it again at the end to null it out.
      */
     void setMoveRepository(@Nullable MoveRepository<Solution_> moveRepository);
+
+    /**
+     * A notifier that can be used to notify a {@link NeighborhoodsBasedMoveRepository} of changes
+     * to the internal state that do not affect any variables (genuine or shadow).
+     * 
+     * @return never null
+     */
+    NeighborhoodNotifier<Solution_> getNeighborhoodNotifier();
 
     /**
      * Calculates the {@link Score} and updates the {@link PlanningSolution working solution} accordingly.

--- a/core/src/main/java/ai/timefold/solver/core/impl/score/director/NeighborhoodNotifier.java
+++ b/core/src/main/java/ai/timefold/solver/core/impl/score/director/NeighborhoodNotifier.java
@@ -1,0 +1,36 @@
+package ai.timefold.solver.core.impl.score.director;
+
+import java.util.function.Consumer;
+
+import ai.timefold.solver.core.impl.neighborhood.NeighborhoodsBasedMoveRepository;
+
+public final class NeighborhoodNotifier<Solution_> implements Consumer<Object> {
+    private boolean isTracking;
+    private NeighborhoodsBasedMoveRepository<Solution_> moveRepository;
+
+    public NeighborhoodNotifier() {
+        isTracking = false;
+    }
+
+    public void setTracking(boolean isTracking) {
+        this.isTracking = isTracking;
+    }
+
+    public NeighborhoodsBasedMoveRepository<Solution_> getMoveRepository() {
+        return moveRepository;
+    }
+
+    public void setMoveRepository(NeighborhoodsBasedMoveRepository<Solution_> moveRepository) {
+        this.moveRepository = moveRepository;
+    }
+
+    @Override
+    public void accept(Object entity) {
+        if (moveRepository == null) {
+            return;
+        }
+        if (isTracking) {
+            moveRepository.update(entity);
+        }
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupplyTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/inverserelation/ExternalizedSingletonInverseVariableSupplyTest.java
@@ -2,9 +2,12 @@ package ai.timefold.solver.core.impl.domain.variable.inverserelation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 import ai.timefold.solver.core.impl.domain.variable.BasicVariableChangeEvent;
 import ai.timefold.solver.core.impl.domain.variable.descriptor.GenuineVariableDescriptor;
@@ -14,6 +17,7 @@ import ai.timefold.solver.core.testdomain.chained.TestdataChainedEntity;
 import ai.timefold.solver.core.testdomain.chained.TestdataChainedSolution;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class ExternalizedSingletonInverseVariableSupplyTest {
 
@@ -22,8 +26,10 @@ class ExternalizedSingletonInverseVariableSupplyTest {
         GenuineVariableDescriptor<TestdataChainedSolution> variableDescriptor =
                 TestdataChainedEntity.buildVariableDescriptorForChainedObject();
         var scoreDirector = mock(InnerScoreDirector.class);
+        @SuppressWarnings("unchecked")
+        var notifier = (Consumer<Object>) mock(Consumer.class);
         ExternalizedSingletonInverseVariableSupply<TestdataChainedSolution> supply =
-                new ExternalizedSingletonInverseVariableSupply<>(variableDescriptor);
+                new ExternalizedSingletonInverseVariableSupply<>(variableDescriptor, notifier);
 
         TestdataChainedAnchor a0 = new TestdataChainedAnchor("a0");
         TestdataChainedEntity a1 = new TestdataChainedEntity("a1", a0);
@@ -47,12 +53,25 @@ class ExternalizedSingletonInverseVariableSupplyTest {
         assertThat(supply.getInverseSingleton(b0)).isSameAs(b1);
         assertThat(supply.getInverseSingleton(b1)).isSameAs(null);
 
+        verify(notifier).accept(a0);
+        verify(notifier).accept(a1);
+        verify(notifier).accept(a2);
+        verify(notifier).accept(b0);
+        // b1 and a3 are not updated as they have no inverse
+        verifyNoMoreInteractions(notifier);
+
+        Mockito.reset(notifier);
+
         supply.beforeChange(scoreDirector, new BasicVariableChangeEvent<>(a3));
         a3.setChainedObject(b1);
         supply.afterChange(scoreDirector, new BasicVariableChangeEvent<>(a3));
 
         assertThat(supply.getInverseSingleton(a2)).isSameAs(null);
         assertThat(supply.getInverseSingleton(b1)).isSameAs(a3);
+
+        verify(notifier).accept(a2);
+        verify(notifier).accept(b1);
+        verifyNoMoreInteractions(notifier);
 
         supply.close();
     }

--- a/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/domain/variable/listener/support/VariableListenerSupportTest.java
@@ -27,6 +27,7 @@ import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInv
 import ai.timefold.solver.core.impl.domain.variable.inverserelation.SingletonInverseVariableListener;
 import ai.timefold.solver.core.impl.domain.variable.supply.SupplyManager;
 import ai.timefold.solver.core.impl.score.director.InnerScoreDirector;
+import ai.timefold.solver.core.impl.score.director.NeighborhoodNotifier;
 import ai.timefold.solver.core.impl.score.director.ValueRangeManager;
 import ai.timefold.solver.core.preview.api.domain.metamodel.VariableMetaModel;
 import ai.timefold.solver.core.testdomain.TestdataEntity;
@@ -41,6 +42,7 @@ import ai.timefold.solver.core.testdomain.shadow.concurrent.TestdataConcurrentVa
 import ai.timefold.solver.core.testdomain.shadow.order.TestdataShadowVariableOrderEntity;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class VariableListenerSupportTest {
 
@@ -214,8 +216,12 @@ class VariableListenerSupportTest {
     @Test
     void shadowVariableListGraphEvents() {
         var solutionDescriptor = TestdataConcurrentSolution.buildSolutionDescriptor();
-        InnerScoreDirector<TestdataConcurrentSolution, HardSoftScore> scoreDirector = mock(InnerScoreDirector.class);
+        @SuppressWarnings("unchecked")
+        var scoreDirector = (InnerScoreDirector<TestdataConcurrentSolution, HardSoftScore>) mock(InnerScoreDirector.class);
+        @SuppressWarnings("unchecked")
+        var neighborhoodNotifier = (NeighborhoodNotifier<TestdataConcurrentSolution>) Mockito.mock(NeighborhoodNotifier.class);
         when(scoreDirector.getSolutionDescriptor()).thenReturn(solutionDescriptor);
+        when(scoreDirector.getNeighborhoodNotifier()).thenReturn(neighborhoodNotifier);
         var valueRangeManager = new ValueRangeManager<>(solutionDescriptor);
         when(scoreDirector.getValueRangeManager()).thenReturn(valueRangeManager);
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsNotificationTest.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/neighborhood/NeighborhoodsNotificationTest.java
@@ -1,0 +1,52 @@
+package ai.timefold.solver.core.impl.neighborhood;
+
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+
+import ai.timefold.solver.core.impl.solver.MoveAsserter;
+import ai.timefold.solver.core.preview.api.domain.metamodel.ElementPosition;
+import ai.timefold.solver.core.preview.api.move.builtin.Moves;
+import ai.timefold.solver.core.testdomain.shadow.simple_list.TestdataDeclarativeSimpleListEntity;
+import ai.timefold.solver.core.testdomain.shadow.simple_list.TestdataDeclarativeSimpleListSolution;
+import ai.timefold.solver.core.testdomain.shadow.simple_list.TestdataDeclarativeSimpleListValue;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class NeighborhoodsNotificationTest {
+    @Test
+    void notifyWhenValueIndexChangesOnSimpleModel() {
+        var neighborhoodMoveRepository = mock(NeighborhoodsBasedMoveRepository.class);
+        var solutionDescriptor = TestdataDeclarativeSimpleListSolution.buildSolutionDescriptor();
+        var variableMetamodel = solutionDescriptor.getListVariableDescriptor().getVariableMetaModel();
+        var moveAsserter = MoveAsserter.create(solutionDescriptor, neighborhoodMoveRepository);
+
+        var solution = new TestdataDeclarativeSimpleListSolution();
+        var entity1 = new TestdataDeclarativeSimpleListEntity("e1", 0, 0);
+        var entity2 = new TestdataDeclarativeSimpleListEntity("e2", 0, 0);
+
+        var value1 = new TestdataDeclarativeSimpleListValue("v1", 0, 0);
+        var value2 = new TestdataDeclarativeSimpleListValue("v2", 0, 0);
+        var value3 = new TestdataDeclarativeSimpleListValue("v3", 0, 0);
+
+        entity1.getValues().add(value1);
+        entity2.getValues().add(value2);
+        entity2.getValues().add(value3);
+
+        solution.setEntityList(List.of(entity1, entity2));
+        solution.setValueList(List.of(value1, value2, value3));
+
+        moveAsserter.applyMove(solution,
+                Moves.change(variableMetamodel,
+                        ElementPosition.of(entity1, 0),
+                        ElementPosition.of(entity2, 0)),
+                () -> Mockito.reset(neighborhoodMoveRepository));
+
+        verify(neighborhoodMoveRepository, atLeastOnce()).update(value1);
+        verify(neighborhoodMoveRepository, atLeastOnce()).update(value2);
+        verify(neighborhoodMoveRepository, atLeastOnce()).update(value3);
+    }
+}

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirector.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirector.java
@@ -7,10 +7,12 @@ import java.util.function.Consumer;
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.api.score.constraint.ConstraintMatchTotal;
 import ai.timefold.solver.core.api.score.constraint.Indictment;
+import ai.timefold.solver.core.impl.neighborhood.MoveRepository;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
 import ai.timefold.solver.core.impl.score.director.InnerScore;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 public final class MoveAssertScoreDirector<Solution_, Score_ extends Score<Score_>>
         extends AbstractScoreDirector<Solution_, Score_, MoveAssertScoreDirectorFactory<Solution_, Score_>> {
@@ -23,6 +25,7 @@ public final class MoveAssertScoreDirector<Solution_, Score_ extends Score<Score
         super(builder);
         this.moveSolutionConsumer = Objects.requireNonNull(builder.moveSolutionConsumer);
         this.isDerived = isDerived;
+        setMoveRepository(builder.moveRepository);
     }
 
     @Override
@@ -66,6 +69,8 @@ public final class MoveAssertScoreDirector<Solution_, Score_ extends Score<Score
             AbstractScoreDirectorBuilder<Solution_, Score_, MoveAssertScoreDirectorFactory<Solution_, Score_>, MoveAssertScoreDirector.Builder<Solution_, Score_>> {
 
         private Consumer<Solution_> moveSolutionConsumer;
+        @Nullable
+        private MoveRepository<Solution_> moveRepository;
 
         public Builder(MoveAssertScoreDirectorFactory<Solution_, Score_> scoreDirectorFactory) {
             super(scoreDirectorFactory);
@@ -73,6 +78,11 @@ public final class MoveAssertScoreDirector<Solution_, Score_ extends Score<Score
 
         public Builder<Solution_, Score_> withMoveSolutionConsumer(Consumer<Solution_> moveSolutionConsumer) {
             this.moveSolutionConsumer = moveSolutionConsumer;
+            return this;
+        }
+
+        public Builder<Solution_, Score_> withMoveRepository(@Nullable MoveRepository<Solution_> moveRepository) {
+            this.moveRepository = moveRepository;
             return this;
         }
 

--- a/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirectorFactory.java
+++ b/core/src/test/java/ai/timefold/solver/core/impl/solver/MoveAssertScoreDirectorFactory.java
@@ -4,27 +4,33 @@ import java.util.function.Consumer;
 
 import ai.timefold.solver.core.api.score.Score;
 import ai.timefold.solver.core.impl.domain.solution.descriptor.SolutionDescriptor;
+import ai.timefold.solver.core.impl.neighborhood.MoveRepository;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirector;
 import ai.timefold.solver.core.impl.score.director.AbstractScoreDirectorFactory;
 
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class MoveAssertScoreDirectorFactory<Solution_, Score_ extends Score<Score_>>
         extends AbstractScoreDirectorFactory<Solution_, Score_, MoveAssertScoreDirectorFactory<Solution_, Score_>> {
 
     private final Consumer<Solution_> moveSolutionConsumer;
+    @Nullable
+    private final MoveRepository<Solution_> moveRepository;
 
     public MoveAssertScoreDirectorFactory(SolutionDescriptor<Solution_> solutionDescriptor,
-            Consumer<Solution_> moveSolutionConsumer) {
+            Consumer<Solution_> moveSolutionConsumer, @Nullable MoveRepository<Solution_> moveRepository) {
         super(solutionDescriptor);
         this.moveSolutionConsumer = moveSolutionConsumer;
+        this.moveRepository = moveRepository;
     }
 
     @Override
     public AbstractScoreDirector.AbstractScoreDirectorBuilder<Solution_, Score_, ?, ?> createScoreDirectorBuilder() {
         return new MoveAssertScoreDirector.Builder<>(this)
-                .withMoveSolutionConsumer(moveSolutionConsumer);
+                .withMoveSolutionConsumer(moveSolutionConsumer)
+                .withMoveRepository(moveRepository);
     }
 
 }


### PR DESCRIPTION
Previously, the neighborhood move repository followed the same update scheme as Constraint Streams, only update an entity when any variable (geninue or shadow) changes. However, the move repository also depends on internal state that may not have a corresponding variable, such as the index of a particular value. This leads to stale moves being generated, causing the wrong index to be used
(possibly even out-of-bounds if an element was removed).

Now, externalized supplies (that is, supplies whose state may change without modifying a variable) notify the neighborhood whenever its internal state for a value changes. These notifications only reach the neighborhood if the move been accepted and won't be undone.

To improve performance, the existing neighborhood updates also only triger if the move been accepted and won't be undone.

Added tests for this new behaviour in the existing externalized tests, as well as a test ensuring all affected values are updated when:

1. No variables (geninue or shadow) are updated
2. Their position in the list changed

Added a new helper method to MoveAsserter that just applies a move (running code after the working solution been set so any passed mocks can be reset).